### PR TITLE
Update diabetes_regression-ci.yml for Azure Pipelines

### DIFF
--- a/.pipelines/diabetes_regression-ci.yml
+++ b/.pipelines/diabetes_regression-ci.yml
@@ -80,7 +80,7 @@ stages:
     variables:
       AMLPIPELINE_ID: $[ dependencies.Get_Pipeline_ID.outputs['getpipelineid.AMLPIPELINEID'] ]
     steps:
-    - task: ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask@0
+    - task: ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask@1
       displayName: 'Invoke ML pipeline'
       inputs:
         azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'


### PR DESCRIPTION
changing @1 because of error 'A task is missing. The pipeline references a task called 'ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask'. This usually indicates the task isn't installed, and you may be able to install it from the Marketplace: https://marketplace.visualstudio.com. (Task version 0, job 'Run_ML_Pipeline', step ''.)'